### PR TITLE
fix(ecs-winston): remove expr from ambient ctx

### DIFF
--- a/loggers/winston/index.d.ts
+++ b/loggers/winston/index.d.ts
@@ -1,4 +1,4 @@
-import type { Format } from "winston";
+import type { Logform } from "winston";
 
 interface Config {
   /**
@@ -27,4 +27,4 @@ interface Config {
   apmIntegration?: boolean;
 }
 
-export = (opts?: Config) => Format
+export default function(opts?: Config): Logform.Format;


### PR DESCRIPTION
- remove executable code in declaration file
- fix missing import error; Format is not exported from the winston root